### PR TITLE
Fixes for unit tests discovered by NAG.

### DIFF
--- a/testunit/AttrVect_Test.F90
+++ b/testunit/AttrVect_Test.F90
@@ -1093,6 +1093,7 @@ i = 4
 call MCT_AtrVt_init(av,iList=variables,lsize=length)
 av%iAttr=i
 
+nullify(out)
 call MCT_AtrVt_exportIAttr(av, keyVar,out)
 do y=1,length
 if(out(y) /= i)then
@@ -1107,6 +1108,8 @@ else
   localResult = 0
   result = 1
 endif
+
+deallocate(out)
 
 call MCT_AtrVt_exportIAttr(av, keyVar,out,size)
 do y=1,length
@@ -1176,6 +1179,7 @@ r = .09_FP
 call MCT_AtrVt_init(av,rList=variables,lsize=length)
 av%rAttr=r
 
+nullify(out)
 call MCT_AtrVt_exportRAttr(av, keyVar,out)
 do y=1,length
 if(out(y) /= r)then
@@ -1190,6 +1194,8 @@ else
   localResult = 0
   result = 1
 endif
+
+deallocate(out)
 
 call MCT_AtrVt_exportRAttr(av, keyVar,out,size)
 do y=1,length
@@ -1261,6 +1267,8 @@ importVectP => importVect
 
 call MCT_AtrVt_init(av,iList=variables,lsize=length)
 call MCT_AtrVt_importIAttr(av,TRIM(keyVar),importVectP)
+
+nullify(out)
 call MCT_AtrVt_exportIAttr(av,TRIM(keyVar),out)
 do y=1,length
 if(out(y) /= i)then
@@ -1274,6 +1282,8 @@ else
   localResult = 0
   result = 1
 endif
+
+deallocate(out)
 
 i=6
 importVect = i
@@ -1350,6 +1360,7 @@ importVectP => importVect
 
 call MCT_AtrVt_init(av,rList=variables,lsize=length)
 call MCT_AtrVt_importRAttr(av,TRIM(keyVar),importVectP)
+nullify(out)
 call MCT_AtrVt_exportRAttr(av,TRIM(keyVar),out)
 do y=1,length
 if(out(y) /= r)then
@@ -1363,6 +1374,8 @@ else
   localResult = 0
   result = 1
 endif
+
+deallocate(out)
 
 r=0.06_FP
 importVect = r

--- a/testunit/master.F90
+++ b/testunit/master.F90
@@ -1,8 +1,8 @@
 program main
 
-use mpi
-
 implicit none
+
+#include "mpif.h"
 
 integer ierr,myProc
 character(len=12) date1
@@ -13,7 +13,7 @@ call MPI_INIT(ierr)
 call MPI_COMM_RANK(MPI_COMM_WORLD,myProc,ierr)
 
 call DATE_AND_TIME(date=date1)
-ui = 6
+ui = 7
 
 if(myProc .eq. 0) call openIO(date1,ui,'AttrVect')
 call testAttrVect(myProc,ui)
@@ -84,8 +84,18 @@ subroutine openIO(stamp,ui,routine)
   character(len=54) filename
   integer ierr
 
+  ierr = 0
+
   filename = trim(routine)//'.log.' // stamp(1:8)
   OPEN (UNIT=ui, FILE=filename,STATUS='NEW',IOSTAT=ierr)
+
+  if (ierr /= 0) then
+     write(6,*) "Open failed on unit: ", ui
+     write(6,*) "File name was: [", filename, "]"
+     write(6,*) "Error code was: ", ierr
+
+     stop 1
+  end if
 
 end subroutine
 


### PR DESCRIPTION
Three fixes were implemented to get these tests to pass in a build with
the NAG Fortran compiler and mpi-serial:

1) Nullify/deallocate pointers before each use, to avoid having them
   point to temporary storage that is too small.

   (There may be memory leaks here as well, but those are not addressed
   by this commit. It is more difficult to track these down because
   AttrVect uses pointers rather than allocatable arrays.)

2) Do not use unit 6 for the log file, since unit 6 is pre-connected to
   standard output. Also, check to make sure that the "open" statement
   succeeds before continuing with tests.

3) Use "mpif.h" instead of the mpi module, so that mpi-serial can be
   used out of the box.
