### PR TITLE
Remove unnecessary include of `malloc.h`.

### DIFF
--- a/mpi-serial/list.c
+++ b/mpi-serial/list.c
@@ -5,11 +5,6 @@
 
 
 
-#ifdef SYSDARWIN
- #include <sys/malloc.h>
-#else
- #include <malloc.h>
-#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include "listops.h"


### PR DESCRIPTION
When mucking around with building MCT through CMake (for CIME unit tests), we found an issue where the `SYSDARWIN` definition in `CPPDEFS` wasn't being used when compiling mpi-serial. That may be a separate bug, but looking at the specific code where it is used, there's this include of `malloc.h`. The right place to get `malloc` is from `stdlib`, not `malloc.h` (which is non-standard), so this needs to just be removed entirely.