### PR TITLE
Support for MPI_Errhandler_set and MPI_Intercomm_merge

### DIFF
--- a/mpi-serial/Makefile
+++ b/mpi-serial/Makefile
@@ -18,6 +18,7 @@ SRCS_C		= mpi.c \
 		  list.c \
 		  handles.c \
                   comm.c \
+		  error.c \
                   group.c \
                   time.c \
                   pack.c \

--- a/mpi-serial/Makefile
+++ b/mpi-serial/Makefile
@@ -19,6 +19,7 @@ SRCS_C		= mpi.c \
 		  handles.c \
                   comm.c \
 		  error.c \
+                  ic_merge.c \
                   group.c \
                   time.c \
                   pack.c \

--- a/mpi-serial/error.c
+++ b/mpi-serial/error.c
@@ -1,0 +1,13 @@
+
+#include "mpiP.h"
+
+/*
+ * Error handling code
+ * Just a stub for now to support the MPI interface without actually 
+ * doing anything
+ */
+
+ int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler handle)
+ {
+   return(MPI_SUCCESS);
+ }

--- a/mpi-serial/ic_merge.c
+++ b/mpi-serial/ic_merge.c
@@ -1,0 +1,15 @@
+
+#include "mpiP.h"
+
+/*
+ * MPI_Intercomm_merge - Creates an intracommunicator from an intercommunicator
+ * This is just a stub for now to support mpi function calls even in Serial
+ * applications. In the case of a serial program, this function is a no-op and 
+ * only ever returns MPI_SUCCESS
+ */
+
+int MPI_Intercomm_merge( MPI_Comm intercomm, int high, MPI_Comm *newintracomm )
+{
+  newintracomm = (MPI_Comm *)intercomm;
+  return(MPI_SUCCESS);
+}

--- a/mpi-serial/mpi.h
+++ b/mpi-serial/mpi.h
@@ -48,7 +48,6 @@ typedef int MPI_Group;
 #define MPI_ERR_IN_STATUS  (-1)
 #define MPI_ERR_LASTCODE   (-1)
 
-
 /*
  * MPI_UNDEFINED
  *
@@ -190,6 +189,14 @@ typedef struct                  /* Fortran: INTEGER status(MPI_STATUS_SIZE) */
 #define MPI_STATUS_IGNORE    ((MPI_Status *)0)
 #define MPI_STATUSES_IGNORE  ((MPI_Status *)0)
 
+
+/*
+ * MPI Errhandling stubs (Not functional currently)
+ */
+typedef int MPI_Errhandler;
+
+#define MPI_ERRORS_ARE_FATAL ((MPI_Errhandler)0)
+#define MPI_ERRORS_RETURN    ((MPI_Errhandler)-1)
 
 
 /*
@@ -388,6 +395,9 @@ extern int MPI_Iprobe(int source, int tag, MPI_Comm comm,
                       int *flag, MPI_Status *status);
 
 extern int MPI_Pack_size(int incount, MPI_Datatype type, MPI_Comm comm, MPI_Aint * size);
+
+/* Error handling stub, not currently functional */
+extern int MPI_Errhandler_set(MPI_Comm comm, MPI_Errhandler handle);
 
 /* new type functions */
 extern int MPI_Get_count(MPI_Status *status, MPI_Datatype datatype, int *count);

--- a/mpi-serial/mpi.h
+++ b/mpi-serial/mpi.h
@@ -253,7 +253,8 @@ typedef int MPI_Info;         /* handle */
 extern int MPI_Intercomm_create(MPI_Comm local_comm, int local_leader,
                           MPI_Comm peer_comm, int remote_leader,
                           int tag, MPI_Comm *newintercomm); 
-
+extern int MPI_Intercomm_merge(MPI_Comm intercomm, int high,
+			       MPI_Comm *newintercomm);
 extern int MPI_Cart_create(MPI_Comm comm_old, int ndims, int *dims,
                         int *periods, int reorder, MPI_Comm *comm_cart);
 extern int MPI_Cart_get(MPI_Comm comm, int maxdims, int *dims,

--- a/mpi-serial/mpif.h
+++ b/mpi-serial/mpif.h
@@ -111,6 +111,9 @@
         integer MPI_ERR_LASTCODE
         parameter (MPI_ERR_LASTCODE= -1)
 
+        integer MPI_ERRORS_RETURN 
+        parameter (MPI_ERRORS_RETURN= -1) 
+
 !
 !
 


### PR DESCRIPTION
This commit adds support for the following MPI functions,
* MPI_Errhandler_set : Currently, the function just returns success and does nothing. Future work should implement this and other MPI_Errhandler functionality. Also adding MPI_ERRORS_ARE_FATAL, MPI_ERRORS_RETURN types.
* MPI_Intercomm_merge:  A no-op that assigns the existing inter comm to the new/merged comm