### PR TITLE
importing swapm implementation of MPI_AlltoallV from PIO

### DIFF
--- a/mct/Makefile
+++ b/mct/Makefile
@@ -31,6 +31,7 @@ SRCS_F90	= m_MCTWorld.F90		\
 		  m_SparseMatrixPlus.F90	\
 		  m_Router.F90			\
 		  m_Rearranger.F90        	\
+		  m_SPMDutils.F90               \
 		  m_Transfer.F90          
 
 OBJS_ALL	= $(SRCS_F90:.F90=.o)
@@ -82,6 +83,7 @@ m_GlobalMap.o:
 m_GlobalSegMap.o:
 m_GlobalSegMapComms.o: m_GlobalSegMap.o
 m_Navigator.o:
+m_SPMDutils.o:
 m_AttrVectComms.o: m_AttrVect.o m_GlobalMap.o
 m_AttrVectReduce.o: m_AttrVect.o
 m_AccumulatorComms.o: m_AttrVect.o m_GlobalMap.o m_AttrVectComms.o
@@ -91,7 +93,7 @@ m_GeneralGridComms.o: m_AttrVect.o m_GeneralGrid.o m_AttrVectComms.o m_GlobalMap
 m_MatAttrVectMul.o: m_AttrVect.o m_SparseMatrix.o m_GlobalMap.o m_GlobalSegMap.o m_SparseMatrixPlus.o m_Rearranger.o
 m_Merge.o: m_AttrVect.o m_GeneralGrid.o
 m_Router.o: m_GlobalToLocal.o m_MCTWorld.o m_GlobalSegMap.o m_ExchangeMaps.o
-m_Rearranger.o: m_Router.o m_MCTWorld.o m_GlobalSegMap.o m_AttrVect.o
+m_Rearranger.o: m_Router.o m_MCTWorld.o m_GlobalSegMap.o m_AttrVect.o m_SPMDutils.o
 m_GlobalToLocal.o: m_GlobalSegMap.o
 m_ExchangeMaps.o: m_GlobalMap.o m_GlobalSegMap.o m_MCTWorld.o m_ConvertMaps.o
 m_ConvertMaps.o: m_GlobalMap.o m_GlobalSegMap.o m_MCTWorld.o

--- a/mct/m_MatAttrVectMul.F90
+++ b/mct/m_MatAttrVectMul.F90
@@ -188,6 +188,7 @@
   logical :: usevector,TrListIsPresent,rListIsPresent
   logical :: contiguous,ycontiguous
 
+
   usevector = .false.
   if(present(Vector)) then
     if(Vector) usevector = .true.
@@ -367,7 +368,6 @@
 	       wgt * xAV%rAttr(inxmin+m,col)
         end do ! m=1,num_indices
      end do ! n=1,num_elements
-
    else
      do n=1,num_elements
 
@@ -508,7 +508,8 @@
      call AttrVect_zero(xPrimeAV)
        ! Rearrange data from x to get x'
      call Rearrange(xAV, xPrimeAV, sMatPlus%XToXPrime, &
-                    sMatPlus%Tag ,vector=usevector)
+                    tag=sMatPlus%Tag, vector=usevector,&
+                    alltoall=.true., handshake=.true.  )
 
        ! Perform perfectly data-local multiply y = Mx'
      if (present(TrList).and.present(rList)) then
@@ -554,13 +555,15 @@
      
        ! Rearrange/reduce partial sums in y' to get y
      if (present(TrList).or.present(rList)) then
-       call Rearrange(yPrimeAV, yAVre, sMatPlus%YPrimeToY, sMatPlus%Tag, &
-                    .TRUE., Vector=usevector)
+       call Rearrange(yPrimeAV, yAVre, sMatPlus%YPrimeToY,            &
+                      tag=sMatPlus%Tag, sum=.TRUE., Vector=usevector, &
+                      alltoall=.true., handshake=.true.               )
        call AttrVect_Rcopy(yAVre,yAV,vector=usevector)
        call AttrVect_clean(yAVre, ierr)
      else
-       call Rearrange(yPrimeAV, yAV, sMatPlus%YPrimeToY, sMatPlus%Tag, &
-                    .TRUE., Vector=usevector)
+       call Rearrange(yPrimeAV, yAV, sMatPlus%YPrimeToY,              &
+                      tag=sMatPlus%Tag, sum=.TRUE., Vector=usevector, &
+                      alltoall=.true., handshake=.true.               )
      endif
        ! Clean up space occupied by y'
      call AttrVect_clean(yPrimeAV, ierr)
@@ -586,8 +589,9 @@
      endif
 
        ! Rearrange data from x to get x'
-     call Rearrange(xAV, xPrimeAV, sMatPlus%XToXPrime, sMatPlus%Tag, &
-                       Vector=usevector)
+     call Rearrange(xAV, xPrimeAV, sMatPlus%XToXPrime,  &
+                    tag=sMatPlus%Tag, Vector=usevector, &
+                    alltoall=.true., handshake=.true.   )
 
        ! Perform perfectly data-local multiply y' = Mx'
      if (present(TrList).and.present(rList)) then
@@ -603,13 +607,15 @@
 
        ! Rearrange/reduce partial sums in y' to get y
      if (present(TrList).or.present(rList)) then
-       call Rearrange(yPrimeAV, yAVre, sMatPlus%YPrimeToY, sMatPlus%Tag, &
-                    .TRUE., Vector=usevector)
+       call Rearrange(yPrimeAV, yAVre, sMatPlus%YPrimeToY,            &
+                      tag=sMatPlus%Tag, sum=.TRUE., Vector=usevector, &
+                      alltoall=.true., handshake=.true.               )
        call AttrVect_Rcopy(yAVre,yAV,vector=usevector)
        call AttrVect_clean(yAVre, ierr)
      else
-       call Rearrange(yPrimeAV, yAV, sMatPlus%YPrimeToY, sMatPlus%Tag, &
-                    .TRUE., Vector=usevector)
+       call Rearrange(yPrimeAV, yAV, sMatPlus%YPrimeToY,              &
+                      tag=sMatPlus%Tag, sum=.TRUE., Vector=usevector, &
+                      alltoall=.true., handshake=.true.               )
      endif
 
        ! Clean up space occupied by x'

--- a/mct/m_Rearranger.F90
+++ b/mct/m_Rearranger.F90
@@ -735,7 +735,7 @@
 !pw++
    ! forcing use of alltoall protocol until additional tuning 
    ! capabilities are added to calling routines
-   usealltoall=.true.
+!pw   usealltoall=.true.
 !pw--
 
    useswapm=.false.
@@ -765,7 +765,7 @@
     ! forcing use of swapm variant of alltoall protocol 
     ! until additional tuning capabilities are added to 
     ! calling routines
-    useswapm=.true.
+!pw    useswapm=.true.
 !pw--
    endif
 

--- a/mct/m_Rearranger.F90
+++ b/mct/m_Rearranger.F90
@@ -531,7 +531,8 @@
 !
 ! !INTERFACE:
 
- subroutine rearrange_(SourceAVin,TargetAV,InRearranger,Tag,Sum,Vector,AlltoAll)
+ subroutine rearrange_(SourceAVin,TargetAV,InRearranger,Tag,Sum,&
+                       Vector,AlltoAll,HandShake,ISend,MaxReq)
 
 !
 ! !USES:
@@ -548,6 +549,7 @@
    use m_AttrVect,  only : nIAttr,nRAttr
    use m_AttrVect,  only : Permute,Unpermute
    use m_Router,    only : Router     
+   use m_SPMDutils, only : m_swapm_int, m_swapm_FP
    use m_realkinds, only : FP
    use m_mpif90
    use m_die
@@ -567,6 +569,9 @@
    logical,          optional, intent(in)      :: Sum
    logical,          optional, intent(in)      :: Vector
    logical,          optional, intent(in)      :: AlltoAll
+   logical,          optional, intent(in)      :: HandShake
+   logical,          optional, intent(in)      :: ISend
+   integer,          optional, intent(in)      :: MaxReq
 
 ! !REVISION HISTORY:
 ! 31Jan02 - E.T. Ong <eong@mcs.anl.gov> - initial prototype
@@ -581,6 +586,8 @@
 ! 14Oct06 - R. Jacob <jacob@mcs.anl.gov> - check value of Sum argument.
 ! 25Jan08 - R. Jacob <jacob@mcs.anl.gov> - Permute/unpermute if the internal
 !           routers permarr is defined.
+! 29Sep16 - P. Worley <worleyph@gmail.com> - added swapm variant of
+!           alltoall option
 !EOP ___________________________________________________________________
 
   character(len=*),parameter :: myname_=myname//'::Rearrange_'
@@ -591,11 +598,11 @@
   integer ::    mp_Type_rp
   integer ::    mytag
   integer ::    ISendSize, RSendSize, IRecvSize, RRecvSize
-  logical ::    usevector, usealltoall
+  logical ::    usevector, usealltoall, useswapm
   logical ::    DoSum
   logical ::    Sendunordered
   logical ::    Recvunordered
-  real(FP) ::  realtyp
+  real(FP)::    realtyp
 !-----------------------------------------------------------------------
 
    ! DECLARE STRUCTURES FOR MPI ARGUMENTS.
@@ -633,6 +640,10 @@
    integer,dimension(:),allocatable  :: IRecvBuf
    real(FP),dimension(:),allocatable :: RRecvBuf
 
+   ! declare arrays to hold MPI data types for m_swapm_XXX calls
+   integer :: ITypes(0:max_nprocs-1)
+   integer :: RTypes(0:max_nprocs-1)
+
    ! Structure to hold MPI request information for sends
    integer :: send_ireqs(max_nprocs)
    integer :: send_rreqs(max_nprocs)
@@ -653,6 +664,16 @@
    type(Router), pointer :: SendRout, RecvRout
    type(AttrVect),pointer :: SourceAv
    type(AttrVect),target  :: SourceAvtmp
+
+   ! local swapm protocol variables and defaults
+   logical,parameter :: DEF_SWAPM_HS     = .true.
+   logical swapm_hs
+
+   logical,parameter :: DEF_SWAPM_ISEND  = .false.
+   logical swapm_isend
+
+   integer,parameter :: DEF_SWAPM_MAXREQ = 512
+   integer swapm_maxreq
 
 !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -708,8 +729,44 @@
    endif
 
    usealltoall=.false.
-   if(present(Alltoall)) then
-    if(Alltoall) usealltoall=.true.
+   if(present(AlltoAll)) then
+    if(AlltoAll) usealltoall=.true.
+   endif
+!pw++
+   ! forcing use of alltoall protocol until additional tuning 
+   ! capabilities are added to calling routines
+   usealltoall=.true.
+!pw--
+
+   useswapm=.false.
+   if (usealltoall) then
+    ! if any swapm-related optional parameters are present,
+    ! enable swapm variant of alltoall
+
+    swapm_hs = DEF_SWAPM_HS
+    if(present(HandShake)) then
+     if(HandShake) swapm_hs=.true.
+     useswapm=.true.
+    endif
+
+    swapm_isend = DEF_SWAPM_ISEND
+    if(present(ISend)) then
+     if(ISend) swapm_isend=.true.
+     useswapm=.true.
+    endif
+
+    swapm_maxreq = DEF_SWAPM_MAXREQ
+    if(present(MaxReq)) then
+     swapm_maxreq=MaxReq
+     useswapm=.true.
+    endif
+
+!pw++
+    ! forcing use of swapm variant of alltoall protocol 
+    ! until additional tuning capabilities are added to 
+    ! calling routines
+    useswapm=.true.
+!pw--
    endif
 
    DoSum=.false.
@@ -855,6 +912,10 @@
            RRdispls(pe)  = RRecvLoc(proc) - 1
         endif
      enddo
+
+     ! SET MPI DATA TYPES
+     ITypes(:) = MP_INTEGER
+     RTypes(:) = mp_Type_rp
   endif
   
 !::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -1090,6 +1151,26 @@ endif  ! end of else for if(usealltoall)
 
 if (usealltoall) then
 
+ if (useswapm) then
+
+  if (numi .ge. 1) then
+     call m_swapm_int(max_pe, myPid,                                    &
+                      ISendBuf, ISendSize, ISendCnts, ISdispls, ITypes, &
+                      IRecvBuf, IRecvSize, IRecvCnts, IRdispls, ITypes, &
+                      ThisMCTWorld%MCT_comm,                            &
+                      swapm_hs, swapm_isend, swapm_maxreq               )
+  endif
+
+  if (numr .ge. 1) then
+     call m_swapm_FP (max_pe, myPid,                                    &
+                      RSendBuf, RSendSize, RSendCnts, RSdispls, RTypes, &
+                      RRecvBuf, RRecvSize, RRecvCnts, RRdispls, RTypes, &
+                      ThisMCTWorld%MCT_comm,                            &
+                      swapm_hs, swapm_isend, swapm_maxreq               )
+  endif
+
+ else
+
   if (numi .ge. 1) then
      call MPI_Alltoallv(ISendBuf, ISendCnts, ISdispls, MP_INTEGER, &
                         IRecvBuf, IRecvCnts, IRdispls, MP_INTEGER, &
@@ -1101,6 +1182,8 @@ if (usealltoall) then
                         RRecvBuf, RRecvCnts, RRdispls, mp_Type_rp, &
                         ThisMCTWorld%MCT_comm,ier)
   endif
+
+ endif
 
 else
 

--- a/mct/m_SPMDutils.F90
+++ b/mct/m_SPMDutils.F90
@@ -1,0 +1,1135 @@
+!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!    Math and Computer Science Division, Argonne National Laboratory   !
+!-----------------------------------------------------------------------
+! CVS $Id$
+! CVS $Name$
+!BOP -------------------------------------------------------------------
+!
+! !MODULE: m_SPMDutils -- Communication operators to address performance
+!                         issues for specific communication patterns
+!
+! !DESCRIPTION:
+! This module provides the swapm equivalent to MPI_Alltoallv that 
+! has proven to be more robust with respect to performance than the
+! MPI collective or the native MCT communication algorithms when the
+! communication pattern is sparse and when load imbalance or send/receive
+! asymmetry leads some processes to be flooded by unexpected messages.
+!
+! Based on algorithms implemented in CAM, but this version modelled after
+! pio_spmd_utils.F90 in PIO1
+!
+! !SEE ALSO:
+!  m_Rearranger
+! 
+!
+! !INTERFACE:
+
+ module m_SPMDutils
+
+      implicit none
+
+      private	! except
+
+! !PUBLIC MEMBER FUNCTIONS:
+
+      public :: m_swapm_int  ! swapm alternative to MPI_AlltoallV for integer data
+      public :: m_swapm_FP   ! swapm alternative to MPI_AlltoallV for FP data
+
+! !DEFINED PARAMETERS:
+
+  character(len=*), parameter :: myname='MCT::m_SPMDutils'
+
+! !REVISION HISTORY:
+! 28Sep16 - P. Worley <worleyph@gmail.com> - initial prototype
+!EOP ___________________________________________________________________
+
+ contains
+
+!========================================================================
+!
+
+   integer function pair(np,p,k)
+
+      integer np,p,k,q
+      q = ieor(p,k)
+      if(q.gt.np-1) then
+         pair = -1
+      else
+         pair = q
+      endif
+      return
+
+   end function pair
+
+!
+!========================================================================
+!
+
+  integer function ceil2(n)
+     integer n,p
+     p=1
+     do while(p.lt.n)
+        p=p*2
+     enddo
+     ceil2=p
+     return
+  end function ceil2
+
+!
+!========================================================================
+!
+   subroutine m_swapm_int ( nprocs, mytask,      &
+      sndbuf, sbuf_siz, sndlths, sdispls, stypes,  &
+      rcvbuf, rbuf_siz, rcvlths, rdispls, rtypes,  &
+      comm, comm_hs, comm_isend, comm_maxreq       )
+
+!----------------------------------------------------------------------- 
+! 
+!> Purpose: 
+!!   Reduced version of original swapm (for swap of multiple messages 
+!!   using MPI point-to-point routines), more efficiently implementing a 
+!!   subset of the swap protocols.
+!! 
+!! Method: 
+!! comm_protocol:
+!!  comm_isend == .true.: use nonblocking send, else use blocking send
+!!  comm_hs == .true.: use handshaking protocol
+!! comm_maxreq:
+!!  =-1,0: do not limit number of outstanding send/receive requests
+!!     >0: do not allow more than min(comm_maxreq, steps) outstanding
+!!         nonblocking send requests or nonblocking receive requests
+!!
+!! Author of original version:  P. Worley
+!! Ported from PIO1: P. Worley, September 2016
+!< 
+!-----------------------------------------------------------------------
+!-----------------------------------------------------------------------
+   use m_mpif90
+   use m_realkinds, only : FP
+   use m_die,       only : MP_perr_die
+
+   implicit none
+!---------------------------Input arguments--------------------------
+!
+   integer, intent(in)   :: nprocs             ! size of communicator
+   integer, intent(in)   :: mytask             ! MPI task id with communicator
+   integer, intent(in)   :: sbuf_siz           ! size of send buffer
+   integer, intent(in)   :: rbuf_siz           ! size of receive buffer
+
+   integer, intent(in)   :: sndlths(0:nprocs-1)! length of outgoing message
+   integer, intent(in)   :: sdispls(0:nprocs-1)! offset from beginning of send
+                                               !  buffer where outgoing messages
+                                               !  should be sent from
+   integer, intent(in)   :: stypes(0:nprocs-1) ! MPI data types
+   integer, intent(in)   :: rcvlths(0:nprocs-1)! length of incoming messages
+   integer, intent(in)   :: rdispls(0:nprocs-1)! offset from beginning of receive 
+                                               !  buffer where incoming messages
+                                               !  should be placed
+   integer, intent(in)   :: rtypes(0:nprocs-1) ! MPI data types
+   integer, intent(in)   :: sndbuf(sbuf_siz)   ! outgoing message buffer
+
+   integer, intent(in)   :: comm               ! MPI communicator
+   logical, intent(in)   :: comm_hs            ! handshaking protocol?
+   logical, intent(in)   :: comm_isend         ! nonblocking send protocol?
+   integer, intent(in)   :: comm_maxreq        ! maximum number of outstanding 
+                                               !  nonblocking requests
+
+!---------------------------Output arguments--------------------------
+!
+   integer, intent(out)  :: rcvbuf(rbuf_siz)   ! incoming message buffer
+
+!
+!---------------------------Local workspace-------------------------------------------
+!
+   character(len=*), parameter :: subName=myname//'::m_swapm_int'
+
+   integer :: steps                            ! number of swaps to initiate
+   integer :: swapids(nprocs)                  ! MPI process id of swap partners
+   integer :: p                                ! process index
+   integer :: istep                            ! loop index
+   integer :: tag                              ! MPI message tag
+   integer :: offset_t                         ! MPI message tag offset, for addressing
+                                               !  message conflict bug (if necessary)
+   integer :: offset_s                         ! index of message beginning in 
+                                               !  send buffer
+   integer :: offset_r                         ! index of message beginning in 
+                                               !  receive buffer
+   integer :: sndids(nprocs)                   ! send request ids
+   integer :: rcvids(nprocs)                   ! receive request ids
+   integer :: hs_rcvids(nprocs)                ! handshake receive request ids
+
+   integer :: maxreq, maxreqh                  ! maximum number of outstanding 
+                                               !  nonblocking requests (and half)
+   integer :: hs                               ! handshake variable
+   integer :: rstep                            ! "receive" step index
+
+   logical :: handshake, sendd                 ! protocol option flags
+
+   integer :: ier                              ! return error status    
+   integer :: status(MP_STATUS_SIZE)           ! MPI status 
+!
+!-------------------------------------------------------------------------------------
+!
+#ifdef _NO_M_SWAPM_TAG_OFFSET
+   offset_t = 0
+#else
+   offset_t = nprocs
+#endif
+!
+   ! if necessary, send to self
+   if (sndlths(mytask) > 0) then
+      tag = mytask + offset_t
+
+      offset_r = rdispls(mytask)+1
+      call mpi_irecv( rcvbuf(offset_r), rcvlths(mytask), rtypes(mytask), &
+                      mytask, tag, comm, rcvids(1), ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+      offset_s = sdispls(mytask)+1
+      call mpi_send( sndbuf(offset_s), sndlths(mytask), stypes(mytask), &
+                     mytask, tag, comm, ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+
+      call mpi_wait( rcvids(1), status, ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+   endif
+
+   ! calculate swap partners and communication ordering
+   steps = 0
+   do istep=1,ceil2(nprocs)-1
+      p = pair(nprocs,istep,mytask)
+      if (p >= 0) then
+         if (sndlths(p) > 0 .or. rcvlths(p) > 0) then
+            steps = steps + 1
+            swapids(steps) = p
+         end if
+      end if
+   end do
+
+   if (steps .eq. 0) return
+
+   ! identify communication protocol
+   if (comm_isend) then
+      sendd = .false.
+   else
+      sendd = .true.
+   endif
+   handshake = comm_hs
+
+   ! identify maximum number of outstanding nonblocking requests to permit
+   if (steps .eq. 1) then
+      maxreq  = 1
+      maxreqh = 1
+   else
+      if (comm_maxreq >= -1) then
+         maxreq = comm_maxreq
+      else
+         maxreq = steps
+      endif
+
+      if ((maxreq .le. steps) .and. (maxreq > 0)) then
+         if (maxreq > 1) then
+            maxreqh = maxreq/2
+         else
+            maxreq  = 2
+            maxreqh = 1
+         endif
+      else
+         maxreq  = steps
+         maxreqh = steps
+      endif
+   endif
+
+! Four protocol options:
+!  (1) handshaking + blocking sends
+   if ((handshake) .and. (sendd)) then
+
+      ! Initialize hs variable
+      hs = 1
+
+      ! Post initial handshake receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+            call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                            hs_rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+
+      ! Post initial receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+            call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data 
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new rsend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_wait  ( hs_rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+
+            call mpi_rsend ( sndbuf(offset_s), sndlths(p), stypes(p), &
+                             p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_RSEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+
+               ! Submit a new handshake irecv request
+               if (sndlths(p) > 0) then
+                  tag = mytask + offset_t
+                  call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                                  hs_rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+
+               ! Submit a new irecv request
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+                  call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+               endif
+            endif
+
+         endif
+!
+      enddo
+
+      ! wait for rest of receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (2) handshaking + nonblocking sends
+   elseif ((handshake) .and. (.not. sendd)) then
+
+      ! Initialize hs variable
+      hs = 1
+
+      ! Post initial handshake receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+            call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                            hs_rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+
+      ! Post initial receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+            call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data 
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new irsend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_wait  ( hs_rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+
+            call mpi_irsend( sndbuf(offset_s), sndlths(p), stypes(p), &
+                             p, tag, comm, sndids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRSEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+
+               ! Submit a new handshake irecv request
+               if (sndlths(p) > 0) then
+                  tag = mytask + offset_t
+                  call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                                  hs_rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+
+               ! Submit a new irecv request
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+                  call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+               endif
+            endif
+
+            ! Wait for outstanding i(r)send request to complete
+            p = swapids(istep-maxreqh)
+            if (sndlths(p) > 0) then
+               call mpi_wait( sndids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+         if (sndlths(p) > 0) then
+            call mpi_wait( sndids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (3) no handshaking + blocking sends
+   elseif ((.not. handshake) .and. (sendd)) then
+
+      ! Post receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data 
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new send request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_send( sndbuf(offset_s), sndlths(p), stypes(p), &
+                           p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            ! Submit a new irecv request
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (4) no handshaking + nonblocking sends
+   elseif ((.not. handshake) .and. (.not. sendd)) then
+
+      ! Post receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data 
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new isend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_isend( sndbuf(offset_s), sndlths(p), stypes(p), &
+                            p, tag, comm, sndids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_ISEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            ! Submit a new irecv request
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+            endif
+
+            ! Wait for outstanding i(r)send request to complete
+            p = swapids(istep-maxreqh)
+            if (sndlths(p) > 0) then
+               call mpi_wait( sndids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+         if (sndlths(p) > 0) then
+            call mpi_wait( sndids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+   endif
+
+   return
+
+   end subroutine m_swapm_int
+
+!
+!========================================================================
+!
+   subroutine m_swapm_FP ( nprocs, mytask,   &
+      sndbuf, sbuf_siz, sndlths, sdispls, stypes,  &
+      rcvbuf, rbuf_siz, rcvlths, rdispls, rtypes,  &
+      comm, comm_hs, comm_isend, comm_maxreq       )
+
+!----------------------------------------------------------------------- 
+! 
+!> Purpose: 
+!!   Reduced version of original swapm (for swap of multiple messages 
+!!   using MPI point-to-point routines), more efficiently implementing a 
+!!   subset of the swap protocols.
+!! 
+!! Method: 
+!! comm_protocol:
+!!  comm_isend == .true.: use nonblocking send, else use blocking send
+!!  comm_hs == .true.: use handshaking protocol
+!! comm_maxreq:
+!!  =-1,0: do not limit number of outstanding send/receive requests
+!!     >0: do not allow more than min(comm_maxreq, steps) outstanding
+!!         nonblocking send requests or nonblocking receive requests
+!!
+!! Author of original version:  P. Worley
+!! Ported from PIO1: P. Worley, September 2016
+!< 
+!-----------------------------------------------------------------------
+!-----------------------------------------------------------------------
+   use m_mpif90
+   use m_realkinds, only : FP
+   use m_die,       only : MP_perr_die
+
+   implicit none
+!---------------------------Input arguments--------------------------
+!
+   integer, intent(in)   :: nprocs             ! size of communicator
+   integer, intent(in)   :: mytask             ! MPI task id with communicator
+   integer, intent(in)   :: sbuf_siz           ! size of send buffer
+   integer, intent(in)   :: rbuf_siz           ! size of receive buffer
+
+   integer, intent(in)   :: sndlths(0:nprocs-1)! length of outgoing message
+   integer, intent(in)   :: sdispls(0:nprocs-1)! offset from beginning of send
+                                               !  buffer where outgoing messages
+                                               !  should be sent from
+   integer, intent(in)   :: stypes(0:nprocs-1) ! MPI data types
+   integer, intent(in)   :: rcvlths(0:nprocs-1)! length of incoming messages
+   integer, intent(in)   :: rdispls(0:nprocs-1)! offset from beginning of receive 
+                                               !  buffer where incoming messages
+                                               !  should be placed
+   integer, intent(in)   :: rtypes(0:nprocs-1) ! MPI data types
+   real(FP),intent(in)   :: sndbuf(sbuf_siz)   ! outgoing message buffer
+
+   integer, intent(in)   :: comm               ! MPI communicator
+   logical, intent(in)   :: comm_hs            ! handshaking protocol?
+   logical, intent(in)   :: comm_isend         ! nonblocking send protocol?
+   integer, intent(in)   :: comm_maxreq        ! maximum number of outstanding 
+                                               !  nonblocking requests
+
+!---------------------------Output arguments--------------------------
+!
+   real(FP), intent(out)  :: rcvbuf(rbuf_siz)   ! incoming message buffer
+
+!
+!---------------------------Local workspace-------------------------------------------
+!
+   character(len=*), parameter :: subName=myname//'::m_swapm_FP'
+
+   integer :: steps                            ! number of swaps to initiate
+   integer :: swapids(nprocs)                  ! MPI process id of swap partners
+   integer :: p                                ! process index
+   integer :: istep                            ! loop index
+   integer :: tag                              ! MPI message tag
+   integer :: offset_t                         ! MPI message tag offset, for addressing
+                                               !  message conflict bug (if necessary)
+   integer :: offset_s                         ! index of message beginning in 
+                                               !  send buffer
+   integer :: offset_r                         ! index of message beginning in 
+                                               !  receive buffer
+   integer :: sndids(nprocs)                   ! send request ids
+   integer :: rcvids(nprocs)                   ! receive request ids
+   integer :: hs_rcvids(nprocs)                ! handshake receive request ids
+
+   integer :: maxreq, maxreqh                  ! maximum number of outstanding 
+                                               !  nonblocking requests (and half)
+   integer :: hs                               ! handshake variable
+   integer :: rstep                            ! "receive" step index
+
+   logical :: handshake, sendd                 ! protocol option flags
+
+   integer :: ier                              ! return error status    
+   integer :: status(MP_STATUS_SIZE)           ! MPI status 
+!
+!-------------------------------------------------------------------------------------
+!
+#ifdef _NO_M_SWAPM_TAG_OFFSET
+   offset_t = 0
+#else
+   offset_t = nprocs
+#endif
+!
+   ! if necessary, send to self
+   if (sndlths(mytask) > 0) then
+      tag = mytask + offset_t
+
+      offset_r = rdispls(mytask)+1
+      call mpi_irecv( rcvbuf(offset_r), rcvlths(mytask), rtypes(mytask), &
+                      mytask, tag, comm, rcvids(1), ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+      offset_s = sdispls(mytask)+1
+      call mpi_send( sndbuf(offset_s), sndlths(mytask), stypes(mytask), &
+                     mytask, tag, comm, ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+
+      call mpi_wait( rcvids(1), status, ier )
+      if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+   endif
+
+   ! calculate swap partners and communication ordering
+   steps = 0
+   do istep=1,ceil2(nprocs)-1
+      p = pair(nprocs,istep,mytask)
+      if (p >= 0) then
+         if (sndlths(p) > 0 .or. rcvlths(p) > 0) then
+            steps = steps + 1
+            swapids(steps) = p
+         end if
+      end if
+   end do
+
+   if (steps .eq. 0) return
+
+   ! identify communication protocol
+   if (comm_isend) then
+      sendd = .false.
+   else
+      sendd = .true.
+   endif
+   handshake = comm_hs
+
+   ! identify maximum number of outstanding nonblocking requests to permit
+   if (steps .eq. 1) then
+      maxreq  = 1
+      maxreqh = 1
+   else
+      if (comm_maxreq >= -1) then
+         maxreq = comm_maxreq
+      else
+         maxreq = steps
+      endif
+
+      if ((maxreq .le. steps) .and. (maxreq > 0)) then
+         if (maxreq > 1) then
+            maxreqh = maxreq/2
+         else
+            maxreq  = 2
+            maxreqh = 1
+         endif
+      else
+         maxreq  = steps
+         maxreqh = steps
+      endif
+   endif
+
+! Four protocol options:
+!  (1) handshaking + blocking sends
+   if ((handshake) .and. (sendd)) then
+
+      ! Initialize hs variable
+      hs = 1
+
+      ! Post initial handshake receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+            call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                            hs_rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+
+      ! Post initial receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+            call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data 
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new rsend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_wait  ( hs_rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+
+            call mpi_rsend ( sndbuf(offset_s), sndlths(p), stypes(p), &
+                             p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_RSEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+
+               ! Submit a new handshake irecv request
+               if (sndlths(p) > 0) then
+                  tag = mytask + offset_t
+                  call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                                  hs_rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+
+               ! Submit a new irecv request
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+                  call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+               endif
+            endif
+
+         endif
+!
+      enddo
+
+      ! wait for rest of receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (2) handshaking + nonblocking sends
+   elseif ((handshake) .and. (.not. sendd)) then
+
+      ! Initialize hs variable
+      hs = 1
+
+      ! Post initial handshake receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+            call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                            hs_rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+
+      ! Post initial receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+            call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data 
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new irsend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_wait  ( hs_rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+
+            call mpi_irsend( sndbuf(offset_s), sndlths(p), stypes(p), &
+                             p, tag, comm, sndids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRSEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+
+               ! Submit a new handshake irecv request
+               if (sndlths(p) > 0) then
+                  tag = mytask + offset_t
+                  call mpi_irecv( hs, 1, MP_INTEGER, p, tag, comm, &
+                                  hs_rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+
+               ! Submit a new irecv request
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+
+                  call mpi_send ( hs, 1, MP_INTEGER, p, tag, comm, ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+               endif
+            endif
+
+            ! Wait for outstanding i(r)send request to complete
+            p = swapids(istep-maxreqh)
+            if (sndlths(p) > 0) then
+               call mpi_wait( sndids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+         if (sndlths(p) > 0) then
+            call mpi_wait( sndids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (3) no handshaking + blocking sends
+   elseif ((.not. handshake) .and. (sendd)) then
+
+      ! Post receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data 
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new send request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_send( sndbuf(offset_s), sndlths(p), stypes(p), &
+                           p, tag, comm, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_SEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            ! Submit a new irecv request
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+!  (4) no handshaking + nonblocking sends
+   elseif ((.not. handshake) .and. (.not. sendd)) then
+
+      ! Post receive requests
+      do istep=1,maxreq
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            tag = p + offset_t
+
+            offset_r = rdispls(p)+1
+            call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                            p, tag, comm, rcvids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+         endif
+      enddo
+      rstep = maxreq
+
+      ! Send (and start receiving) data 
+      do istep=1,steps
+         p = swapids(istep)
+
+         ! Submit new isend request
+         if (sndlths(p) > 0) then
+            tag = mytask + offset_t
+
+            offset_s = sdispls(p)+1
+            call mpi_isend( sndbuf(offset_s), sndlths(p), stypes(p), &
+                            p, tag, comm, sndids(istep), ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_ISEND',ier)
+         endif
+
+         if (istep > maxreqh) then
+
+            ! Wait for oldest irecv request to complete
+            p = swapids(istep-maxreqh)
+            if (rcvlths(p) > 0) then
+               call mpi_wait( rcvids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+            ! Submit a new irecv request
+            if (rstep < steps) then
+               rstep = rstep + 1
+               p = swapids(rstep)
+               if (rcvlths(p) > 0) then
+                  tag = p + offset_t
+
+                  offset_r = rdispls(p)+1
+                  call mpi_irecv( rcvbuf(offset_r), rcvlths(p), rtypes(p), &
+                                  p, tag, comm, rcvids(rstep), ier )
+                  if(ier /= 0) call MP_perr_die(subName,'MPI_IRECV',ier)
+               endif
+            endif
+
+            ! Wait for outstanding i(r)send request to complete
+            p = swapids(istep-maxreqh)
+            if (sndlths(p) > 0) then
+               call mpi_wait( sndids(istep-maxreqh), status, ier )
+               if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+            endif
+
+         endif
+
+      enddo
+
+      ! wait for rest of send and receive requests to complete
+      do istep=steps-maxreqh+1,steps
+         p = swapids(istep)
+         if (rcvlths(p) > 0) then
+            call mpi_wait( rcvids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+         if (sndlths(p) > 0) then
+            call mpi_wait( sndids(istep), status, ier )
+            if(ier /= 0) call MP_perr_die(subName,'MPI_WAIT',ier)
+         endif
+      enddo
+
+   endif
+
+   return
+
+   end subroutine m_swapm_FP
+
+end module m_SPMDutils
+
+
+
+
+


### PR DESCRIPTION
For high resolution runs of ACME and CESM using large
MPI process counts, the existing MPI algorithms in the
rearrange_ routine can be inefficient. The swapm variant
of the MPI_AlltoallV operator was ported from PIO1 and
modified to work in the MCT environment. The option to
call this was then added to rearrange_ . For the short
term, rearrange_ only calls swapm (and not MPI_AlltoallV
for the existing MPI-1 point-to-point communication
algorithm) and uses fixed swapm parameter options that
are anticipated to be resonable choices for most
situations. Long term, the routines calling rearrange_
should be modified to allow the user to specify an MPI
algorithm and communication protocol.

Update: Based on performance experiments on Titan, using
the swapm option with handshaking enabled for all calls to
rearrange_ is not as efficient as using this option only
in calls to rearrange_ from sMatAvMult_SMPlus_ . Changed
logic to implement this restriction. While it may be
useful in other locations as well, these locations are
still to be determined.

Should be BFB - if not, then there is a bug.