### PR TITLE
Decrease serial complexity of initp_ algorithm

### DIFF
--- a/mct/m_Router.F90
+++ b/mct/m_Router.F90
@@ -268,7 +268,7 @@
 !           increasing.  Instead, permute it to increasing and proceed.
 ! 07Sep12 - T. Craig <tcraig@ucar.edu> - Replace a double loop with a single
 !           to improve speed for large proc and segment counts.
-! 12Nov16 - P. Worley <worleyph@gmail.com> - eliminate iterations in double
+! 12Nov16 - P. Worley <worleyph@gmail.com> - eliminate iterations in nested
 !           loop that can be determined to be unnecessary
 !EOP -------------------------------------------------------------------
 


### PR DESCRIPTION
These changes implement two different optimizations
for the initp_ routine in m_Router.F90

The first optimization uses a preprocessing step to
attempt to determine a subset of processes to loop
over, so as to decrease the serial complexity of a
later, expensive, nested loop. It also uses this to
decrease the size of the local arrays
allocated/deallocated within the routine. In current
practice in ACME, this does very little, as the
preprocessing step seldom decreases the number of
iterations of the expensive nested loop much. As
there is little cost to this, leaving it in in case
it is useful in the future.

The second optimization adds additional logic to the
expensive nested loop to eliminate iterations of the
inner loops that are known to be unnecesary based on
preprocessed information and from information gained
from earlier iterations of the outer loop. This decreases
the cost of this nested loop significantly. This is
of little importance on Titan, decreasing intialization
cost by a minute or two, but it decreases the cost of
intialization on Mira from 106 minutes to 26 minutes
for a production-like high resolution coupled model runs.
While affecting only the initialization, the high
initialization cost on Mira makes development and testing
very difficult.

[BFB]