### PR TITLE
Initialize the sMat to zero

### DIFF
--- a/testsystem/testall/ReadSparseMatrixAsc.F90
+++ b/testsystem/testall/ReadSparseMatrixAsc.F90
@@ -25,6 +25,7 @@
       use m_List,         only : List_init => init
       use m_List,         only : List_clean => clean
 
+      use m_AttrVect,     only : Attrvect_zero => zero
       use m_SparseMatrix, only : SparseMatrix
       use m_SparseMatrix, only : SparseMatrix_Init => init
       use m_SparseMatrix, only : SparseMatrix_Clean => clean
@@ -155,6 +156,7 @@
   nRows = dst_dims(1) * dst_dims(2)
   nColumns = src_dims(1) * src_dims(2)
   call SparseMatrix_init(sMat, nRows, nColumns, num_elements)
+  call AttrVect_zero(sMat%data)
 
        ! ...and store them.
 


### PR DESCRIPTION
After the sMat is initialized, set all the arrays in the Av to zero.
This will allow later calls to get_local_row to return a valid value.

Fixes #43 