### PR TITLE
impi performance fix for MCTWorld:initm

### DIFF
--- a/mct/m_MCTWorld.F90
+++ b/mct/m_MCTWorld.F90
@@ -315,10 +315,16 @@
 !
 ! allocate space to hold global ids
 ! only needed on root, but allocate everywhere to avoid complaints.
-      allocate(Gprocids(mysize),stat=ier)
+      if (myLid==0) then
+         allocate(Gprocids(mysize),stat=ier)
+      else
+         allocate(Gprocids(1),stat=ier)
+      endif
       if(ier/=0) call die(myname_,'allocate(Gprocids)',ier)
 ! gather over the LOCAL comm
       call MPI_GATHER(myGid,1,MP_INTEGER,Gprocids,1,MP_INTEGER,0,mycomms(i),ier)
+      call MPI_Barrier(mycomms(i), ier)
+
       if(ier/=0) call die(myname_,'MPI_GATHER Gprocids',ier)
 
       if(myLid == 0) then
@@ -372,7 +378,6 @@
    deallocate(compids,reqs,status,nprocs,tmparray,stat=ier)
    if(ier/=0) call die(myname_,'deallocate(compids,..)',ier)
  endif
-
  end subroutine initm_
 
 !BOP -------------------------------------------------------------------
@@ -473,7 +478,7 @@
 !
 ! !DESCRIPTION:
 ! Initialize MCTWorld using information valid only on the global root.
-! This is called by initm\_ but could also be called by the user
+! This is called by initm_ but could also be called by the user
 ! for very complex model--processor geometries.
 !
 ! !INTERFACE:


### PR DESCRIPTION
Was having problems with extremely long start up times using impi on large task counts
(10,000 to 100,000.)  In the process of debugging found that adding this barrier and avoiding an unnecessary allocation on non-root tasks improves the startup performance greatly (down from 2 or more hours to 5 minutes or less).   Don't have a good explination for this at this time, but it should be harmless.