### PR TITLE
Fix for building m_AttrVect.F90 using Cray compilers

### DIFF
--- a/mct/m_AttrVect.F90
+++ b/mct/m_AttrVect.F90
@@ -845,7 +845,6 @@
   if(myZeroInts) then ! zero out INTEGER attributes
      if(List_allocated(aV%iList)) then
         if(associated(aV%iAttr) .and. (nIAttr_(aV)>0)) then
-!DIR$ COLLAPSE
            aV%iAttr=0
         endif
      endif
@@ -854,7 +853,6 @@
   if(myZeroReals) then ! zero out REAL attributes
      if(List_allocated(aV%rList)) then
         if(associated(aV%rAttr) .and. (nRAttr_(aV)>0)) then
-!DIR$ COLLAPSE
            aV%rAttr=0._FP
         endif
      endif


### PR DESCRIPTION
Remove 2 compiler directives that Cray compiler didn't like.

Fixes #68 
