### PR TITLE
add an install for mpiserial

### DIFF
--- a/mpi-serial/Makefile
+++ b/mpi-serial/Makefile
@@ -8,7 +8,7 @@ VPATH=$(SRCDIR)/mpi-serial
 MODULE		= mpi-serial
 
 SRCS_F90	= fort.F90 \
-                  mpif.F90
+		  mpif.F90
 
 SRCS_C		= mpi.c \
 		  send.c \
@@ -17,20 +17,20 @@ SRCS_C		= mpi.c \
 		  req.c \
 		  list.c \
 		  handles.c \
-                  comm.c \
+		  comm.c \
 		  error.c \
-                  ic_merge.c \
-                  group.c \
-                  time.c \
-                  pack.c \
-                  type.c \
-                  type_const.c \
-                  copy.c \
-                  op.c \
-                  cart.c \
-                  getcount.c \
-                  probe.c \
-                  info.c
+		  ic_merge.c \
+		  group.c \
+		  time.c \
+		  pack.c \
+		  type.c \
+		  type_const.c \
+		  copy.c \
+		  op.c \
+		  cart.c \
+		  getcount.c \
+		  probe.c \
+		  info.c
 
 
 OBJS_ALL	= $(SRCS_C:.c=.o) \
@@ -76,6 +76,9 @@ MYF90FLAGS=$(INCPATH) $(DEFS) $(FCFLAGS)  $(MPEUFLAGS)
 
 .PHONY: clean tests install
 
+includedir = $(PREFIX)/include
+libdir = $(PREFIX)/lib
+
 clean:
 	/bin/rm -f *.o ctest ftest $(LIB) mpi.mod config.log config.status
 	cd tests ; $(MAKE) clean
@@ -83,11 +86,9 @@ clean:
 tests:
 	cd tests; make
 
-install: lib
+install: $(LIB)
 	$(MKINSTALLDIRS) $(libdir) $(includedir)
 	$(INSTALL) lib$(MODULE).a -m 644 $(libdir)
 	$(INSTALL) mpi.h -m 644 $(includedir)
 	$(INSTALL) mpif.h -m 644 $(includedir)
-
-
-
+	$(INSTALL) *.mod -m 644 $(includedir)


### PR DESCRIPTION
This install path will simplify the [spack workflow](https://github.com/spack/spack/tree/develop/var/spack/repos/builtin/packages/mpi-serial).  